### PR TITLE
Address Feedback

### DIFF
--- a/email-templates/PR-message-to-list.txt
+++ b/email-templates/PR-message-to-list.txt
@@ -1,6 +1,6 @@
 Hi all,
 
-We wanted to let the list know that the sergeant-at-arms (SAA) team (described in more detail at [1]) has determined that [NAME] has engaged in a pattern of abuse based on [his|her] recent messages to this list [2][3]. Their posting rights to the ietf@ietf.org mailing list have been restricted for the next 14 days.  We encourage everyone to review the IETF discussion list charter [4] and avoid postings that include unprofessional commentary [5]. 
+We wanted to let the list know that the sergeant-at-arms (SAA) team (described in more detail at [1]) has determined that [NAME] has engaged in a pattern of abuse based on their recent messages to this list [2][3]. Their posting rights to the ietf@ietf.org mailing list have been restricted for the next 14 days.  We encourage everyone to review the IETF discussion list charter [4] and avoid postings that include unprofessional commentary [5]. 
 
 Thanks,
 [NAME] on behalf of the SAA team

--- a/email-templates/PR-message-to-list.txt
+++ b/email-templates/PR-message-to-list.txt
@@ -1,6 +1,6 @@
 Hi all,
 
-We wanted to let the list know that the sergeant-at-arms (SAA) team (described in more detail at [1]) has determined that [NAME] has engaged in a pattern of abuse based on [his|her] recent messages to this list [2][3]. We encourage everyone to review the IETF discussion list charter [4] and avoid postings that include unprofessional commentary [5]. 
+We wanted to let the list know that the sergeant-at-arms (SAA) team (described in more detail at [1]) has determined that [NAME] has engaged in a pattern of abuse based on [his|her] recent messages to this list [2][3]. Their posting rights to the ietf@ietf.org mailing list have been restricted for the next 14 days.  We encourage everyone to review the IETF discussion list charter [4] and avoid postings that include unprofessional commentary [5]. 
 
 Thanks,
 [NAME] on behalf of the SAA team

--- a/email-templates/README.md
+++ b/email-templates/README.md
@@ -1,0 +1,24 @@
+# Email Templates
+
+These are the templates used by the SAA to communicate with individuals and the list about an incident, grouped by escalation level, then by category (where applicable) and intended recipient.
+
+## Level 0: Friendly suggestion
+* Appropriate Forum
+  - [To List](./forum-to-list.txt)
+
+* Unauthorized Announcments
+  - [To sender](./announcements.txt)
+  - [To list](./announcements-to-list.txt)
+
+* Unprofessional Commentary
+  - [To sender](./first-message.txt)
+  - [](./first-message-to-list.txt)
+
+## Level 1: Cooling off period
+
+* [To sender](./first-pattern-of-abuse-message.txt)
+
+## Level 2: Temporary posting rights restriction
+
+* [To sender](./second-pattern-of-abuse-message.txt)
+* [To list](./PR-message-to-list.txt)

--- a/email-templates/README.md
+++ b/email-templates/README.md
@@ -3,16 +3,15 @@
 These are the templates used by the SAA to communicate with individuals and the list about an incident, grouped by escalation level, then by category (where applicable) and intended recipient.
 
 ## Level 0: Friendly suggestion
+
 * Appropriate Forum
   - [To List](./forum-to-list.txt)
-
 * Unauthorized Announcments
   - [To sender](./announcements.txt)
   - [To list](./announcements-to-list.txt)
-
 * Unprofessional Commentary
   - [To sender](./first-message.txt)
-  - [](./first-message-to-list.txt)
+  - [To list](./first-message-to-list.txt)
 
 ## Level 1: Cooling off period
 

--- a/email-templates/README.md
+++ b/email-templates/README.md
@@ -11,11 +11,11 @@ These are the templates used by the SAA to communicate with individuals and the 
   - [To list](./announcements-to-list.txt)
 * Unprofessional Commentary
   - [To sender](./first-message.txt)
-  - [To list](./first-message-to-list.txt)
 
 ## Level 1: Cooling off period
 
 * [To sender](./first-pattern-of-abuse-message.txt)
+* [To list](./first-message-to-list.txt)
 
 ## Level 2: Temporary posting rights restriction
 

--- a/email-templates/announcements-to-list.txt
+++ b/email-templates/announcements-to-list.txt
@@ -1,6 +1,6 @@
 Hi all,
 
-We wanted to let the list know that the sergeant-at-arms (SAA) team (described in more detail at [1]) has been in touch with [NAME] off-list concerning [his|her] recent message [2]. We encourage everyone to review the IETF discussion list charter [3] and avoid postings that includes announcements of conferences, events, or activities that are not sponsored or endorsed by the Internet Society or IETF. 
+We wanted to let the list know that the sergeant-at-arms (SAA) team (described in more detail at [1]) has been in touch with [NAME] off-list concerning their recent message [2]. We encourage everyone to review the IETF discussion list charter [3] and avoid postings that includes announcements of conferences, events, or activities that are not sponsored or endorsed by the Internet Society or IETF. 
 
 Thanks,
 [NAME] on behalf of the SAA team

--- a/email-templates/first-message-to-list.txt
+++ b/email-templates/first-message-to-list.txt
@@ -1,6 +1,6 @@
 Hi all,
 
-We wanted to let the list know that the sergeant-at-arms (SAA) team (described in more detail at [1]) has been in touch with [NAME] off-list concerning [his|her] recent messages [2][3]. We encourage everyone to review the IETF discussion list charter [4] and avoid postings that include unprofessional commentary [5]. 
+We wanted to let the list know that the sergeant-at-arms (SAA) team (described in more detail at [1]) has been in touch with [NAME] off-list concerning their recent messages [2][3]. We encourage everyone to review the IETF discussion list charter [4] and avoid postings that include unprofessional commentary [5]. 
 
 Thanks,
 [NAME] on behalf of the SAA team

--- a/sop.md
+++ b/sop.md
@@ -28,9 +28,9 @@ The SAA team member also requests that the individual take a voluntary 5-day "co
 
 ### Level 2: Temporary posting rights restriction
 
-An SAA team member sends an off-list message to the individual on behalf of the SAA team, with saa@ietf.org on cc. This message clearly identifies the concern and offers assistance with re-framing language.
+An SAA team member sends an off-list message to the individual on behalf of the SAA team, with saa@ietf.org on cc. This message clearly identifies the concern and offers assistance with re-framing language and highlights the pattern of abuse. An offer to assist with re-framing language is also included.
 
-Subject to the approval by the IETF Chair, the SAA team member also informs the individual that his or her posting rights to ietf@ietf.org will be restricted for 14 days.  The SAA team member informs the individual that a note will be sent to ietf@ietf.org to inform the list that the SAA has restricted the posting rights.
+Subject to the approval by the IETF Chair, the SAA team member also informs the individual that his or her posting rights to ietf@ietf.org will be restricted for 14 days. The SAA team member informs the individual that a note will be sent to ietf@ietf.org to inform the list that the SAA has restricted the posting rights.
 
 ## Finding a more specific forum
 

--- a/sop.md
+++ b/sop.md
@@ -28,9 +28,9 @@ The SAA team member also requests that the individual take a voluntary 5-day "co
 
 ### Level 2: Temporary posting rights restriction
 
-An SAA team member sends an off-list message to the individual on behalf of the SAA team, with saa@ietf.org on cc. This message clearly identifies the concern and offers assistance with re-framing language and highlights the pattern of abuse. An offer to assist with re-framing language is also included.
+An SAA team member sends an off-list message to the individual on behalf of the SAA team, with saa@ietf.org on cc. This message clearly identifies the concern and the pattern of abuse, and offers assistance with re-framing language.
 
-Subject to the approval by the IETF Chair, the SAA team member also informs the individual that his or her posting rights to ietf@ietf.org will be restricted for 14 days. The SAA team member informs the individual that a note will be sent to ietf@ietf.org to inform the list that the SAA has restricted the posting rights.
+Subject to the approval by the IETF Chair, the SAA team member also informs the individual that his or her posting rights to ietf@ietf.org will be restricted for 14 days. The SAA team member informs the individual that a note will be sent to ietf@ietf.org to inform the list that the SAA has restricted their posting rights.
 
 ## Finding a more specific forum
 

--- a/sop.md
+++ b/sop.md
@@ -8,7 +8,7 @@ The sergeant-at-arms (SAA) team consists of the sergeants-at-arms and the IETF C
 
 The sergeants-at-arms strive to monitor all postings on ietf@ietf.org on a daily basis. The IETF Chair also monitors the list but may not be in a position to read each message or monitor every day.
 
-When a member of the SAA team sees a list posting that may be considered inappropriate according to [RFC 3005] and the [Unprofessional Commentary Description], the team member reports it to saa@ietf.org. Subscribers to ietf@ietf.org are also encouraged to report postings they believe to be inappropriate under those guidelines to saa@ietf.org. 
+When a member of the SAA team sees a list posting that may be considered inappropriate according to [RFC 3005] or the [Unprofessional Commentary Description], the team member reports it to saa@ietf.org. Subscribers to ietf@ietf.org are also encouraged to report postings they believe to be inappropriate under those guidelines to saa@ietf.org. 
 
 A report made by a member of the SAA team should include a suggested action in response, including specific text for email(s) to the original poster and/or the list, as appropriate. The SAA team uses a standard set of [email-templates]. Proposed emails to either individuals or to the list must be vetted and approved by at least one other SAA team member before being sent.
 
@@ -30,7 +30,7 @@ The SAA team member also requests that the individual take a voluntary 5-day "co
 
 An SAA team member sends an off-list message to the individual on behalf of the SAA team, with saa@ietf.org on cc. This message clearly identifies the concern and offers assistance with re-framing language.
 
-The SAA team member also informs the individual that his or her posting rights to ietf@ietf.org will be restricted for 14 days. The SAA team member informs the individual that a note will be sent to ietf@ietf.org to inform the list that the SAA is continuing to engage with the individual.
+Subject to the approval by the IETF Chair, the SAA team member also informs the individual that his or her posting rights to ietf@ietf.org will be restricted for 14 days. The SAA team member informs the individual that a note will be sent to ietf@ietf.org to inform the list that the SAA is continuing to engage with the individual.
 
 ## Finding a more specific forum
 

--- a/sop.md
+++ b/sop.md
@@ -30,9 +30,7 @@ The SAA team member also requests that the individual take a voluntary 5-day "co
 
 An SAA team member sends an off-list message to the individual on behalf of the SAA team, with saa@ietf.org on cc. This message clearly identifies the concern and offers assistance with re-framing language.
 
-Subject to the approval by the IETF Chair, the SAA team member also informs the individual that his or her posting rights to ietf@ietf.org will be restricted for 14 days.  The SAA team member
-informs the individual that a note will be sent to ietf@ietf.org to
-inform the list that the SAA has restricted the posting rights.
+Subject to the approval by the IETF Chair, the SAA team member also informs the individual that his or her posting rights to ietf@ietf.org will be restricted for 14 days.  The SAA team member informs the individual that a note will be sent to ietf@ietf.org to inform the list that the SAA has restricted the posting rights.
 
 ## Finding a more specific forum
 

--- a/sop.md
+++ b/sop.md
@@ -8,7 +8,7 @@ The sergeant-at-arms (SAA) team consists of the sergeants-at-arms and the IETF C
 
 The sergeants-at-arms strive to monitor all postings on ietf@ietf.org on a daily basis. The IETF Chair also monitors the list but may not be in a position to read each message or monitor every day.
 
-When a member of the SAA team sees a list posting that may be considered inappropriate according to [RFC 3005] or the [Unprofessional Commentary Description], the team member reports it to saa@ietf.org. Subscribers to ietf@ietf.org are also encouraged to report postings they believe to be inappropriate under those guidelines to saa@ietf.org. 
+When IETF discussion list subscribers believe that a posting that may be considered inappropriate according to [RFC 3005] or the [Unprofessional Commentary Description], they are encouraged to report it to saa@ietf.org. Please note that SAA team members are also subscribers to the IETF discussion list and they follow the same process to report posts that they consider inappropriate.
 
 A report made by a member of the SAA team should include a suggested action in response, including specific text for email(s) to the original poster and/or the list, as appropriate. The SAA team uses a standard set of [email-templates]. Proposed emails to either individuals or to the list must be vetted and approved by at least one other SAA team member before being sent.
 
@@ -30,7 +30,9 @@ The SAA team member also requests that the individual take a voluntary 5-day "co
 
 An SAA team member sends an off-list message to the individual on behalf of the SAA team, with saa@ietf.org on cc. This message clearly identifies the concern and offers assistance with re-framing language.
 
-Subject to the approval by the IETF Chair, the SAA team member also informs the individual that his or her posting rights to ietf@ietf.org will be restricted for 14 days. The SAA team member informs the individual that a note will be sent to ietf@ietf.org to inform the list that the SAA is continuing to engage with the individual.
+Subject to the approval by the IETF Chair, the SAA team member also informs the individual that his or her posting rights to ietf@ietf.org will be restricted for 14 days.  The SAA team member
+informs the individual that a note will be sent to ietf@ietf.org to
+inform the list that the SAA has restricted the posting rights.
 
 ## Finding a more specific forum
 
@@ -38,7 +40,7 @@ RFC 3005 explains that:
 
 "Discussions that fall within the area of any working group or well established list should be moved to such more specific forum as soon as this is pointed out, unless the issue is one for which the working group needs wider input or direction."
 
-The SAA team will make friendly suggestions to the list in cases where discussions should be moved to more specific forums. 
+The SAA team will make friendly suggestions to the list in cases where discussions should be moved to more specific forums along with a pointer to the more specific forum(s). 
 
 ## Announcements
 


### PR DESCRIPTION
Addresses most of the feedback received, excluding any directory/file renames.

Notes:

* It was suggested to change instances of "I" to "We" in the templates, however that requires much more substantive changes to keep the messages understandable.
* It was suggested to rename the templates based on the escalation level they apply to.  That was not done in this PR in order to keep the content changes reviewable; a follow-up can be made to address that.